### PR TITLE
Consulta al padrón A4

### DIFF
--- a/Tests/CensusA4Test.php
+++ b/Tests/CensusA4Test.php
@@ -1,0 +1,122 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+use AfipServices\WebServices\Census\CensusA4Service;
+use AfipServices\AccessTicketManager;
+use AfipServices\AccessTicket;
+use \Mockery as m;
+
+class CensusA4Test extends TestCase {
+
+	private $census;
+
+	public function tearDown(){
+ 		m::close();
+ 	}
+
+ 	public function setUp(){
+
+ 		$this->census = new CensusA4Service(
+			m::mock('SoapClient'),
+			m::mock('AfipServices\AccessTicketProvider'),
+			m::mock('AfipServices\AccessTicket')
+		);
+
+ 	}
+	
+	public function testInstance(){
+	 	$this->assertInstanceOf( 'AfipServices\WebServices\Census\CensusA4Service', $this->census );
+	}
+
+	/**	 
+	 * @expectedException \ArgumentCountError
+	 */  	
+	public function testInstanceWithNoArguments(){
+		new CensusA4Service();
+	}	
+
+	public function testShouldBeAccessTicketClient(){
+	 	$this->assertInstanceOf( 'AfipServices\AccessTicketClient', $this->census );
+	}
+
+	/**	 
+	 * @expectedException AfipServices\WSException
+	 */  
+	public function testAccessTicketShouldHaveTaxId(){
+
+		$at_mock = m::mock('AfipServices\AccessTicket');
+		$at_mock->shouldReceive('getTaxId')
+			    ->once()
+			    ->andReturn( null );
+
+		$census = new CensusA4Service(
+			m::mock('SoapClient'),
+			m::mock('AfipServices\AccessTicketProvider'),
+			$at_mock
+		);
+
+		$census->getAT();
+	}
+
+	 
+	public function testShouldReturnAccessTicket(){
+
+		$ws_mock = m::mock('AfipServices\WebServices\WebService');
+
+		$at_mock = m::mock('AfipServices\AccessTicket');
+		$at_mock->shouldReceive('getTaxId')
+			    ->once()
+			    ->andReturn( '12345678' );
+
+		$atp_mock = m::mock('AfipServices\AccessTicketProvider');
+		$atp_mock->shouldReceive('processAccessTicket')
+			     ->once();
+
+		$census = new CensusA4Service(
+			m::mock('SoapClient'),
+			$atp_mock,
+			$at_mock
+		);
+
+		$this->assertInstanceOf( 'AfipServices\AccessTicket', $census->getAT() );
+	}
+
+  public function testShoudReturnPersonData() {
+		$at_mock = m::mock('AfipServices\AccessTicket');
+		$at_mock->shouldReceive('getTaxId')
+			    ->andReturn( '12345678' );
+
+    $at_mock->shouldReceive('getToken')
+        ->once()
+        ->andReturn('random token');
+
+    $at_mock->shouldReceive('getSign')
+        ->once()
+        ->andReturn('very secret sign');
+
+    $soap_mock = m::mock('SoapClient');
+    $soap_mock->shouldReceive('getPersona')
+        ->once()
+        ->with([
+            'token' => 'random token',
+            'sign' => 'very secret sign',
+            'cuitRepresentada' => '12345678',
+            'idPersona' => 'personaId'
+        ])
+        ->andReturn( (object)(['personaReturn' => (object)['persona' => 'datos de la persona' ]]));
+
+		$atp_mock = m::mock('AfipServices\AccessTicketProvider');
+		$atp_mock->shouldReceive('processAccessTicket')
+			     ->times(3);
+
+		$census = new CensusA4Service(
+			$soap_mock,
+			$atp_mock,
+			$at_mock
+		);
+
+    $this->assertSame('datos de la persona', $census->getPersona('personaId'));
+  }
+
+
+}

--- a/Traits/FileManager.php
+++ b/Traits/FileManager.php
@@ -85,7 +85,7 @@ trait FileManager
   protected function tempFolderPermissionsCheck()
   {
     if (!is_writable($this->getTempFolderPath())) {
-      throw new WSException("La carpeta Temp debe tener permisos de escritura");
+      throw new WSException(sprintf("La carpeta %s debe tener permisos de escritura", $this->getTempFolderPath()));
     };
   }
 

--- a/WebServices/Census/CensusA4Service.php
+++ b/WebServices/Census/CensusA4Service.php
@@ -1,0 +1,108 @@
+<?php
+namespace AfipServices\WebServices\Census;
+
+use AfipServices\WSException;
+use AfipServices\WSHelper;
+use AfipServices\AccessTicket;
+use AfipServices\AccessTicketClient;
+use AfipServices\AccessTicketProvider;
+use AfipServices\WebServices\WebService;
+use AfipServices\Traits\FileManager;
+
+/**
+ * WebService de padron ws_sr_padron_a4
+ */
+Class CensusA4Service extends WebService implements AccessTicketClient{
+
+	use FileManager;
+
+	protected $service_name = 'ws_sr_padron_a4';
+	protected $soap_client;
+	protected $access_ticket_provider;
+	protected $access_ticket;
+
+	/**
+	 * @param SoapClient $soap_client SoapClientFactory::create( [wsdl], [end_point] )
+	 * @param AccessTicketProvider $acces_ticket_manager el objeto encargado de procesar y completar el AccessTicket
+	 * @param AccessTicket $access_ticket
+	 */ 
+	public function __construct( \SoapClient $soap_client,
+								 AccessTicketProvider $access_ticket_provider, 
+								 AccessTicket $access_ticket  ){
+    parent::__construct();
+		$this->soap_client = $soap_client;
+		$this->access_ticket_provider = $access_ticket_provider;
+		$this->access_ticket = $access_ticket;
+	}
+
+	/**
+	 * Devuelve el nombre del servicio
+   *
+	 * @return string
+	 */ 
+	public function getServiceName(){
+		return $this->service_name;
+	}
+
+	/**
+	 * Devuelve el access ticket
+	 * @return AccessTicket
+	 */ 
+	public function getAccessTicket(){
+		return $this->access_ticket;
+	}
+
+	/**
+	 * Le solicita el Ticket de Acceso al AccessTicketProvider
+	 * @return AccessTicket
+	 */ 
+	public function getAT(){
+
+		if( !$this->access_ticket->getTaxId() ){			
+			throw new WSException("El Ticket de acceso al WSFE de Afip debe tener cuit", $this);			
+		}
+
+		$this->access_ticket_provider->processAccessTicket( $this );
+		return $this->access_ticket;
+	}
+
+
+	/**
+	 * Solicitar datos de una persona
+	 * @param string $data  
+	 * @return array
+	 * @throws  WSException 
+	 */
+	public function getPersona( $data ){
+
+		$request_params = $this->_buildGetPersonaParams( $data );
+		try{
+		  $response = $this->soap_client->getPersona( $request_params );
+    } catch (\SoapFault $e){
+      $msg = ($e->getMessage());
+      throw new WSException($msg, $this);
+    }
+    return $response->personaReturn->persona;
+	}	
+
+
+	/**
+	 * Armar el array para ser enviado al servicio y solicitar el cae
+	 * @param array $data
+	 * @return array $params
+	 */ 
+	private function _buildGetPersonaParams( $idPersona ){
+
+		$params = [ 
+      'token' => $this->getAT()->getToken(),
+      'sign' => $this->getAT()->getSign(),
+      'cuitRepresentada' => $this->getAT()->getTaxId(),
+      'idPersona' => $idPersona,
+		];
+
+
+		return $params;
+	}
+
+
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Clases para interactuar con api de Afip",
     "type": "library",
     "require": {
-        
+        "ext-soap": "*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.9",

--- a/ws_padron_a4.php
+++ b/ws_padron_a4.php
@@ -1,0 +1,49 @@
+<?php
+
+use AfipServices\WSException;
+use AfipServices\AccessTicket;
+use AfipServices\Factories\AuthServiceFactory;
+use AfipServices\Factories\BillerServiceFactory;
+
+if (php_sapi_name() != 'cli') {
+  throw new Exception('This application must be run on the command line.');
+}
+
+
+if( !file_exists( 'conf.php' ) ){	
+    throw new Exception("Copia el contenido de conf.example.php a conf.php y completa los datos correctamente\n");	
+}
+
+require_once('vendor/autoload.php');
+$conf = include( 'conf.php' );
+
+$auth_conf = $conf['wsaa'];
+
+try {
+
+    # $ats = new AfipServices\Auth\AccessTicketStore();
+
+    /* Servicio de autenticacion */
+    $auth = AuthServiceFactory::create( $auth_conf['wsdl'], 
+                                        $auth_conf['end_point'],
+                                        $auth_conf['cert_file_name'],
+                                        $auth_conf['key_file_name'],
+                                        $auth_conf['passprhase']
+                                        );
+
+		$wsdl = 'https://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA4?WSDL';
+    $ep = 'https://awshomo.afip.gov.ar/sr-padron/webservices/personaServiceA4?WSDL';
+		$soapClient = new \SoapClient( $wsdl, [
+                    'location'       => $ep,
+                ]);
+    $censusA4 = new AfipServices\WebServices\Census\CensusA4Service($soapClient,
+        $auth,
+        new \AfipServices\AccessTicket($conf['cuit']));
+
+    var_dump($censusA4->getPersona('20000000516'));
+} catch ( WSException $e ) {
+    var_dump( $e );
+    throw $e;
+}
+
+


### PR DESCRIPTION
Desde Noviembre del 2017, el servicio de consulta REST de padrón no está más activo y es necesario utilizar el servicio de autentificación para obtener los datos.

Se creó una clase CensusA4Service para poder llamar al servicio ws_sr_padron_a4

Se incluye un ejemplo de ejecución